### PR TITLE
24 feat change tag marker from killercoda to interactive

### DIFF
--- a/docs/examples/complete-docs-example.md
+++ b/docs/examples/complete-docs-example.md
@@ -13,7 +13,7 @@ killercoda:
     imageid: ubuntu
 ---
 
-<!-- Killercoda intro.md START -->
+<!-- INTERACTIVE intro.md START -->
 
 # Sending OpenTelemetry logs to Loki using Alloy
 
@@ -29,11 +29,11 @@ Before you begin, ensure you have the following to run the demo:
 - Docker
 - Docker Compose
 
-<!-- Killercoda ignore START -->
+<!-- INTERACTIVE ignore START -->
 {{< admonition type="note" >}}
 Alternatively, you can try out this example in our online sandbox. Which is a fully configured environment with all the dependencies pre-installed. You can access the sandbox [here](https://killercoda.com/grafana-labs/course/loki/alloy-otel-logs).
 {{< /admonition >}}
-<!-- Killercoda ignore END -->
+<!-- INTERACTIVE ignore END -->
 
 ## Scenario
 
@@ -49,34 +49,34 @@ In this scenario, we have a microservices application called the Carnivourse Gre
 
 Each service generates logs using the OpenTelemetry SDK and exports to Alloy in the OpenTelemetry format. Alloy then ingests the logs and sends them to Loki. We will configure Alloy to ingest OpenTelemetry logs, send them to Loki, and view the logs in Grafana.
 
-<!-- Killercoda intro.md END -->
+<!-- INTERACTIVE intro.md END -->
 
-<!-- Killercoda step1.md START -->
+<!-- INTERACTIVE step1.md START -->
 
 ## Step 1: Environment setup
 
 In this step, we will set up our environment by cloning the repository that contains our demo application and spinning up our observability stack using Docker Compose.
 
 1. To get started, clone the repository that contains our demo application:
-    <!-- Killercoda exec START -->
+    <!-- INTERACTIVE exec START -->
     ```bash
     git clone -b microservice-otel  https://github.com/grafana/loki-fundamentals.git
     ```
-    <!-- Killercoda exec END -->
+    <!-- INTERACTIVE exec END -->
 1.  Next we will spin up our observability stack using Docker Compose:
 
-    <!-- Killercoda ignore START -->
+    <!-- INTERACTIVE ignore START -->
     ```bash
     docker compose -f loki-fundamentals/docker-compose.yml up -d
     ```
-    <!-- Killercoda ignore END -->
+    <!-- INTERACTIVE ignore END -->
 
-    <!-- Killercoda include START -->
+    <!-- INTERACTIVE include START -->
 
     <!--  ```bash -->
     <!-- docker-compose -f loki-fundamentals/docker-compose.yml up -d -->
     <!--  ```{{exec}} -->
-    <!-- Killercoda include END -->
+    <!-- INTERACTIVE include END -->
 
     This will spin up the following services:
     ```bash
@@ -88,24 +88,24 @@ In this step, we will set up our environment by cloning the repository that cont
 We will be access two UI interfaces:
 - Alloy at [http://localhost:12345](http://localhost:12345)
 - Grafana at [http://localhost:3000](http://localhost:3000)
-<!-- Killercoda step1.md END -->
+<!-- INTERACTIVE step1.md END -->
 
-<!-- Killercoda step2.md START -->
+<!-- INTERACTIVE step2.md START -->
 
 ## Step 2: Configure Alloy to ingest OpenTelemetry logs
 
 To configure Alloy to ingest OpenTelemetry logs, we need to update the Alloy configuration file. To start, we will update the `config.alloy` file to include the OpenTelemetry logs configuration.
 
-<!-- Killercoda include START -->
+<!-- INTERACTIVE include START -->
 <!-- **Note: Killercoda has an inbuilt Code editor which can be accessed via the `Editor` tab.** -->
-<!-- Killercoda include END -->
+<!-- INTERACTIVE include END -->
 
 ### OpenTelelmetry Logs Receiver
 
 First, we will configure the OpenTelemetry logs receiver. This receiver will accept logs via HTTP and gRPC.
 
 Open the `config.alloy` file in the `loki-fundamentals` directory and copy the following configuration:
-<!-- Killercoda copy START -->
+<!-- INTERACTIVE copy START -->
 
 ```alloy
  otelcol.receiver.otlp "default" {
@@ -118,7 +118,7 @@ Open the `config.alloy` file in the `loki-fundamentals` directory and copy the f
  }
 ```
 
-<!-- Killercoda copy END -->
+<!-- INTERACTIVE copy END -->
 
 
 ### OpenTelemetry Logs Processor
@@ -126,7 +126,7 @@ Open the `config.alloy` file in the `loki-fundamentals` directory and copy the f
 Next, we will configure the OpenTelemetry logs processor. This processor will batch the logs before sending them to the logs exporter.
 
 Open the `config.alloy` file in the `loki-fundamentals` directory and copy the following configuration:
-<!-- Killercoda copy START -->
+<!-- INTERACTIVE copy START -->
 ```alloy
 otelcol.processor.batch "default" {
     output {
@@ -134,14 +134,14 @@ otelcol.processor.batch "default" {
     }
 }
 ```
-<!-- Killercoda copy END -->
+<!-- INTERACTIVE copy END -->
 
 ### OpenTelemetry Logs Exporter
 
 Lastly, we will configure the OpenTelemetry logs exporter. This exporter will send the logs to Loki.
 
 Open the `config.alloy` file in the `loki-fundamentals` directory and copy the following configuration:
-<!-- Killercoda copy START -->
+<!-- INTERACTIVE copy START -->
 ```alloy
 otelcol.exporter.otlphttp "default" {
   client {
@@ -149,16 +149,16 @@ otelcol.exporter.otlphttp "default" {
   }
 }
 ```
-<!-- Killercoda copy END -->
+<!-- INTERACTIVE copy END -->
 
 ### Reload the Alloy configuration
 
 Once added, save the file. Then run the following command to request Alloy to reload the configuration:
-<!-- Killercoda exec START -->
+<!-- INTERACTIVE exec START -->
 ```bash
 curl -X POST http://localhost:12345/-/reload
 ```
-<!-- Killercoda exec END -->
+<!-- INTERACTIVE exec END -->
 
 The new configuration will be loaded this can be verified by checking the Alloy UI: [http://localhost:12345](http://localhost:12345).
 
@@ -166,42 +166,42 @@ The new configuration will be loaded this can be verified by checking the Alloy 
 
 If you get stuck or need help creating the configuration, you can copy and replace the entire `config.alloy` using the completed configuration file:
 
-<!-- Killercoda exec START -->
+<!-- INTERACTIVE exec START -->
 ```bash
 cp loki-fundamentals/completed/config.alloy loki-fundamentals/config.alloy
 curl -X POST http://localhost:12345/-/reload
 ```
-<!-- Killercoda exec END -->
+<!-- INTERACTIVE exec END -->
 
-<!-- Killercoda step2.md END -->
+<!-- INTERACTIVE step2.md END -->
 
-<!-- Killercoda step3.md START -->
+<!-- INTERACTIVE step3.md START -->
 
 ## Step 3: Start the Carnivorous Greenhouse
 
 In this step, we will start the Carnivorous Greenhouse application. To start the application, run the following command:
-<!-- Killercoda ignore START -->
+<!-- INTERACTIVE ignore START -->
 {{< admonition type="note" >}}
 This docker-compose file relies on the `loki-fundamentals_loki` docker network. If you have not started the observability stack, you will need to start it first.
 {{< /admonition >}}
-<!-- Killercoda ignore END -->
+<!-- INTERACTIVE ignore END -->
 
-<!-- Killercoda include START -->
+<!-- INTERACTIVE include START -->
 <!-- **Note: This docker-compose file relies on the `loki-fundamentals_loki` docker network. If you have not started the observability stack, you will need to start it first.** -->
-<!-- Killercoda include END -->
+<!-- INTERACTIVE include END -->
 
-<!-- Killercoda ignore START -->
+<!-- INTERACTIVE ignore START -->
 ```bash
 docker compose -f lloki-fundamentals/greenhouse/docker-compose-micro.yml up -d --build 
 ```
-<!-- Killercoda ignore END -->
+<!-- INTERACTIVE ignore END -->
 
-<!-- Killercoda include START -->
+<!-- INTERACTIVE include START -->
 
 <!--  ```bash -->
 <!-- docker-compose -f loki-fundamentals/greenhouse/docker-compose-micro.yml up -d --build  -->
 <!--  ```{{exec}} -->
-<!-- Killercoda include END -->
+<!-- INTERACTIVE include END -->
 
 This will start the following services:
 ```bash
@@ -224,4 +224,4 @@ Once started, you can access the Carnivorous Greenhouse application at [http://l
 Finally to view the logs in Loki, navigate to the Loki Logs Explore view in Grafana at [http://localhost:3000/a/grafana-lokiexplore-app/explore](http://localhost:3000/a/grafana-lokiexplore-app/explore).
 
 
-<!-- Killercoda step3.md END -->
+<!-- INTERACTIVE step3.md END -->

--- a/docs/transformer.md
+++ b/docs/transformer.md
@@ -66,25 +66,25 @@ Copy directives tell the transform tool to make the contained fenced code block 
 The start marker is:
 
 ```markdown
-<!-- Killercoda copy START -->
+<!-- INTERACTIVE copy START -->
 ```
 
 The end marker is:
 
 ```markdown
-<!-- Killercoda copy END -->
+<!-- INTERACTIVE copy END -->
 ```
 
 #### Examples
 
 ````markdown
-<!-- Killercoda copy START -->
+<!-- INTERACTIVE copy START -->
 
 ```bash
 echo 'Hello, world!'
 ```
 
-<!-- Killercoda copy END -->
+<!-- INTERACTIVE copy END -->
 ````
 
 Produces:
@@ -106,25 +106,25 @@ Exec directives tell the transform tool to make the contained fenced code block 
 The start marker is:
 
 ```markdown
-<!-- Killercoda exec START -->
+<!-- INTERACTIVE exec START -->
 ```
 
 The end marker is:
 
 ```markdown
-<!-- Killercoda exec END -->
+<!-- INTERACTIVE exec END -->
 ```
 
 #### Examples
 
 ````markdown
-<!-- Killercoda exec START -->
+<!-- INTERACTIVE exec START -->
 
 ```bash
 echo 'Hello, world!'
 ```
 
-<!-- Killercoda exec END -->
+<!-- INTERACTIVE exec END -->
 ````
 
 Produces:
@@ -146,13 +146,13 @@ The finish directive specifies the start and end of the section of the file to u
 The start marker is:
 
 ```markdown
-<!-- Killercoda finish.md START -->
+<!-- INTERACTIVE finish.md START -->
 ```
 
 The end marker is:
 
 ```markdown
-<!-- Killercoda finish.md END -->
+<!-- INTERACTIVE finish.md END -->
 ```
 
 ### Ignore
@@ -162,13 +162,13 @@ The ignore directive tells the transform tool to skip the contents within the ma
 The start marker is:
 
 ```markdown
-<!-- Killercoda ignore START -->
+<!-- INTERACTIVE ignore START -->
 ```
 
 The end marker is:
 
 ```markdown
-<!-- Killercoda ignore END -->
+<!-- INTERACTIVE ignore END -->
 ```
 
 #### Examples
@@ -176,11 +176,11 @@ The end marker is:
 ```markdown
 Information common to both pages.
 
-<!-- Killercoda ignore START -->
+<!-- INTERACTIVE ignore START -->
 
 Information unique to the Grafana website page.
 
-<!-- Killercoda ignore END -->
+<!-- INTERACTIVE ignore END -->
 ```
 
 Produces:
@@ -197,13 +197,13 @@ The HTML comments aren't rendered on the Grafana website.
 The start marker is:
 
 ```markdown
-<!-- Killercoda include START -->
+<!-- INTERACTIVE include START -->
 ```
 
 The end marker is:
 
 ```markdown
-<!-- Killercoda include END -->
+<!-- INTERACTIVE include END -->
 ```
 
 #### Examples
@@ -211,9 +211,9 @@ The end marker is:
 ```markdown
 Information common to both pages.
 
-<!-- Killercoda include START -->
+<!-- INTERACTIVE include START -->
 <!-- Information unique to the Killercoda page. -->
-<!-- Killercoda include END -->
+<!-- INTERACTIVE include END -->
 ```
 
 Produces:
@@ -231,13 +231,13 @@ The intro directive specifies the start and end of the section of the file to us
 The start marker is:
 
 ```markdown
-<!-- Killercoda intro.md START -->
+<!-- INTERACTIVE intro.md START -->
 ```
 
 The end marker is:
 
 ```markdown
-<!-- Killercoda intro.md END -->
+<!-- INTERACTIVE intro.md END -->
 ```
 
 ### Step
@@ -247,13 +247,13 @@ The step directive specifies the start and end of the section of the file to use
 The start marker is the following, where _`<N>`_ is the number of the step:
 
 ```markdown
-<!-- Killercoda step<N>.md START -->
+<!-- INTERACTIVE step<N>.md START -->
 ```
 
 The end marker is the following, where _`<N>`_ is the number of the step:
 
 ```markdown
-<!-- Killercoda step<N>.md END -->
+<!-- INTERACTIVE step<N>.md END -->
 ```
 
 ## Generate a tutorial
@@ -299,7 +299,7 @@ To generate a tutorial:
 
    Each step starts at the [step](#step) directive start marker and ends at the [step](#step) directive end marker.
    Include at least one step.
-   The first step use the start marker `<!-- Killercoda step1.md START -->` and the end marker `<!-- Killercoda step1.md END -->`
+   The first step use the start marker `<!-- INTERACTIVE step1.md START -->` and the end marker `<!-- INTERACTIVE step1.md END -->`
 
 1. Configure a finish page.
 

--- a/loki/alloy-otel-logs/index.json
+++ b/loki/alloy-otel-logs/index.json
@@ -1,6 +1,6 @@
 {
-  "title": "Ingesting OpenTelemetry logs to Loki using Alloy",
-  "description": "Configuring Grafana Alloy to ingest OpenTelemetry logs to Loki.",
+  "title": "Sending OpenTelemetry logs to Loki using Alloy",
+  "description": "Configuring Grafana Alloy to send OpenTelemetry logs to Loki.",
   "details": {
     "intro": {
       "text": "intro.md"

--- a/loki/alloy-otel-logs/intro.md
+++ b/loki/alloy-otel-logs/intro.md
@@ -1,6 +1,12 @@
-# Ingesting OpenTelemetry logs to Loki using Alloy
+# Sending OpenTelemetry logs to Loki using Alloy
 
-Alloy natively supports ingesting OpenTelemetry logs. In this example, we will configure Alloy to ingest OpenTelemetry logs to Loki.
+Alloy natively supports receiving logs in the OpenTelemetry format. This allows you to send logs from applications instrumented with OpenTelemetry to Alloy, which can then be sent to Loki for storage and visualization in Grafana. In this example, we will make use of 3 Alloy components to achieve this:
+
+- **OpenTelemetry Logs Receiver:** This receiver will accept logs via HTTP and gRPC.
+
+- **OpenTelemetry Logs Processor:** This processor will batch the logs before sending them to the logs exporter.
+
+- **OpenTelemetry Logs Exporter:** This exporter will send the logs to Loki.
 
 ## Dependencies
 

--- a/tools/transformer/main.go
+++ b/tools/transformer/main.go
@@ -219,7 +219,7 @@ func transform(srcFilePath, dstDirPath string) error {
 	)
 
 	for i := 1; i <= 5; i++ {
-		if regexp.MustCompile(fmt.Sprintf(`<!-- Killercoda step%d.md START -->`, i)).Match(data) {
+		if regexp.MustCompile(fmt.Sprintf(`<!-- INTERACTIVE step%d.md START -->`, i)).Match(data) {
 			steps++
 
 			if err := writeStep(dstDirPath, i, data, transformers, renderer); err != nil {

--- a/tools/transformer/transform.go
+++ b/tools/transformer/transform.go
@@ -19,18 +19,18 @@ var (
 )
 
 const (
-	copyStartMarker    = "<!-- Killercoda copy START -->"
-	copyEndMarker      = "<!-- Killercoda copy END -->"
-	execStartMarker    = "<!-- Killercoda exec START -->"
-	execEndMarker      = "<!-- Killercoda exec END -->"
-	finishStartMarker  = "<!-- Killercoda finish.md START -->"
-	finishEndMarker    = "<!-- Killercoda finish.md END -->"
-	ignoreStartMarker  = "<!-- Killercoda ignore START -->"
-	ignoreEndMarker    = "<!-- Killercoda ignore END -->"
-	includeStartMarker = "<!-- Killercoda include START -->"
-	includeEndMarker   = "<!-- Killercoda include END -->"
-	introStartMarker   = "<!-- Killercoda intro.md START -->"
-	introEndMarker     = "<!-- Killercoda intro.md END -->"
+	copyStartMarker    = "<!-- INTERACTIVE copy START -->"
+	copyEndMarker      = "<!-- INTERACTIVE copy END -->"
+	execStartMarker    = "<!-- INTERACTIVE exec START -->"
+	execEndMarker      = "<!-- INTERACTIVE exec END -->"
+	finishStartMarker  = "<!-- INTERACTIVE finish.md START -->"
+	finishEndMarker    = "<!-- INTERACTIVE finish.md END -->"
+	ignoreStartMarker  = "<!-- INTERACTIVE ignore START -->"
+	ignoreEndMarker    = "<!-- INTERACTIVE ignore END -->"
+	includeStartMarker = "<!-- INTERACTIVE include START -->"
+	includeEndMarker   = "<!-- INTERACTIVE include END -->"
+	introStartMarker   = "<!-- INTERACTIVE intro.md START -->"
+	introEndMarker     = "<!-- INTERACTIVE intro.md END -->"
 )
 
 func isMarker(node ast.Node, source []byte, marker string) bool {
@@ -509,8 +509,8 @@ type StepTransformer struct {
 // It removes all other nodes resulting in a document that only contains the content between the markers.
 // It removes the markers themselves.
 func (t *StepTransformer) Transform(root *ast.Document, reader text.Reader, _ parser.Context) {
-	stepStartMarker := fmt.Sprintf("<!-- Killercoda step%d.md START -->", t.Step)
-	stepEndMarker := fmt.Sprintf("<!-- Killercoda step%d.md END -->", t.Step)
+	stepStartMarker := fmt.Sprintf("<!-- INTERACTIVE step%d.md START -->", t.Step)
+	stepEndMarker := fmt.Sprintf("<!-- INTERACTIVE step%d.md END -->", t.Step)
 
 	source := reader.Source()
 

--- a/tools/transformer/transform_test.go
+++ b/tools/transformer/transform_test.go
@@ -32,23 +32,23 @@ func TestActionTransformer_Transform(t *testing.T) {
 		src := []byte("1. Create a directory called `evaluate-loki` for the demo environment.\n" +
 			"   Make `evaluate-loki` your current working directory:\n" +
 			"\n" +
-			"   <!-- Killercoda copy START -->\n" +
+			"   <!-- INTERACTIVE copy START -->\n" +
 			"\n" +
 			"   ```bash\n" +
 			"   mkdir evaluate-loki\n" +
 			"   cd evaluate-loki\n" +
 			"   ```\n" +
 			"\n" +
-			"   <!-- Killercoda copy END -->\n" +
+			"   <!-- INTERACTIVE copy END -->\n" +
 			"\n" +
-			"   <!-- Killercoda copy START -->\n" +
+			"   <!-- INTERACTIVE copy START -->\n" +
 			"\n" +
 			"   ```bash\n" +
 			"   mkdir evaluate-loki\n" +
 			"   cd evaluate-loki\n" +
 			"   ```\n" +
 			"\n" +
-			"   <!-- Killercoda copy END -->\n")
+			"   <!-- INTERACTIVE copy END -->\n")
 
 		root := md.Parser().Parse(text.NewReader(src))
 		require.NoError(t, md.Renderer().Render(w, src, root))
@@ -208,13 +208,13 @@ func TestIgnoreTransformer_Transform(t *testing.T) {
 
 	src := []byte(`## Install Loki and collecting sample logs
 
-<!-- Killercoda ignore START -->
+<!-- INTERACTIVE ignore START -->
 
 {{< admonition type="note" >}}
 This quickstart assumes you are running Linux.
 {{< /admonition >}}
 
-<!-- Killercoda ignore END -->
+<!-- INTERACTIVE ignore END -->
 
 **To install Loki locally, follow these steps:**
 `)
@@ -241,11 +241,11 @@ func TestIncludeTransformer_Transform(t *testing.T) {
 	md.Parser().AddOptions(parser.WithASTTransformers(util.Prioritized(&IncludeTransformer{}, 0)))
 	md.SetRenderer(renderer.NewRenderer(renderer.WithNodeRenderers(util.Prioritized(markdown.NewRenderer(), 1000))))
 
-	src := []byte("<!-- Killercoda include START -->\n" +
+	src := []byte("<!-- INTERACTIVE include START -->\n" +
 		"<!-- ```bash -->\n" +
 		"<!-- docker-compose up -d -->\n" +
 		"<!-- ```{{exec}} -->\n" +
-		"<!-- Killercoda include END -->\n")
+		"<!-- INTERACTIVE include END -->\n")
 
 	root := md.Parser().Parse(text.NewReader(src))
 	require.NoError(t, md.Renderer().Render(w, src, root))
@@ -268,7 +268,7 @@ func TestIntroTransformer_Transform(t *testing.T) {
 	md.Parser().AddOptions(parser.WithASTTransformers(util.Prioritized(&IntroTransformer{}, 0)))
 	md.SetRenderer(renderer.NewRenderer(renderer.WithNodeRenderers(util.Prioritized(markdown.NewRenderer(), 1000))))
 
-	src := []byte(`<!-- Killercoda intro.md START -->
+	src := []byte(`<!-- INTERACTIVE intro.md START -->
 
 # Quickstart to run Loki locally
 
@@ -279,7 +279,7 @@ The Docker Compose configuration instantiates the following components, each in 
 - **Grafana Alloy** which scrapes the log lines from flog, and pushes them to Loki through the gateway.
 - **Grafana** which provides visualization of the log lines captured within Loki.
 
-<!-- Killercoda intro.md END -->
+<!-- INTERACTIVE intro.md END -->
 `)
 
 	root := md.Parser().Parse(text.NewReader(src))


### PR DESCRIPTION
Updated the directive markers to `INTERACTIVE`. This will currently be a breaking change for all docs using old syntax wonder if its worth adding a feature to allow both to work or just get the old pages updated.

I also haven't updated the metadata naming conventions let me know what you both think about this. I am open to making those generic aswell but a lot of the metadata might be killercoda specific. 