### PR TITLE
Default to adding the {{copy}} Killercoda action to all fenced code blocks

### DIFF
--- a/tools/transformer/transform.go
+++ b/tools/transformer/transform.go
@@ -95,7 +95,7 @@ func (t *ActionTransformer) Transform(node *ast.Document, reader text.Reader, _ 
 				toRemove = append(toRemove, child)
 			}
 
-			if inMarker {
+			if inMarker || t.Kind == "copy" {
 				if fenced, ok := child.(*ast.FencedCodeBlock); ok {
 					fenced.SetAttributeString("data-killercoda-"+t.Kind, "true")
 				}


### PR DESCRIPTION
No need to use the `copy` directive, the default is copyable.
The `exec` directive overrides the `{{copy}}` action if its used.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>