### PR TITLE
killercoda-grafana-fundamentals update

### DIFF
--- a/grafana/grafana-fundamentals/index.json
+++ b/grafana/grafana-fundamentals/index.json
@@ -1,6 +1,6 @@
 {
   "title": "Grafana fundamentals",
-  "description": "Learn how to use Grafana to set up a monitoring solution for your application. You will explore metrics and logs, build and annotate dashboards, and set up alerts.",
+  "description": "Learn how to use Grafana to set up a monitoring solution for your application. You will explore metrics and logs, build and annotate dashboards, and set up alert rules.",
   "details": {
     "intro": {
       "text": "intro.md"

--- a/grafana/grafana-fundamentals/intro.md
+++ b/grafana/grafana-fundamentals/intro.md
@@ -8,4 +8,4 @@ In this tutorial, you’ll learn how to use Grafana to set up a monitoring solut
 
 - Annotate dashboards
 
-- Set up alerts
+- Set up alert rules

--- a/grafana/grafana-fundamentals/step10.md
+++ b/grafana/grafana-fundamentals/step10.md
@@ -1,4 +1,4 @@
-# Add an Alert Rule to Grafana
+# Add an alert rule to Grafana
 
 Now that Grafana knows how to notify us, it’s time to set up an alert rule:
 
@@ -8,7 +8,7 @@ Now that Grafana knows how to notify us, it’s time to set up an alert rule:
 
 1. For **Section 1**, name the rule `fundamentals-test`{{copy}}.
 
-1. For **Section 2**, Find the **query A** box. Choose your Prometheus datasource. Note that the rule type should automatically switch to Grafana-managed alert.
+1. For **Section 2**, Find the **query A** box. Choose your Prometheus datasource. Note that the rule type should automatically switch to Grafana-managed alert rule.
 
 1. Switch to code mode by checking the Builder/Code toggle.
 
@@ -20,29 +20,29 @@ Now that Grafana knows how to notify us, it’s time to set up an alert rule:
 
 1. Press **Preview**. You should see some data returned.
 
-1. Keep expressions “B” and “C” as they are. These expressions (Reduce and Threshold, respectively) come by default when creating a new rule. Expression “B”, selects the last value of our query “A”, while the Threshold expression “C” will check if the last value from expression “B” is above a specific value. In addition, the Threshold expression is the alert condition by default. Enter `0.2`{{copy}} as threshold value. [You can read more about queries and conditions here](https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/queries-conditions/#expression-queries).
+1. Keep expressions “B” and “C” as they are. These expressions (Reduce and Threshold, respectively) come by default when creating a new rule. Expression “B”, selects the last value of our query “A”, while the Threshold expression “C” will check if the last value from expression “B” is above a specific value. In addition, the Threshold expression is the alert rule condition by default. Enter `0.2`{{copy}} as threshold value. [You can read more about queries and conditions here](https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/queries-conditions/#expression-queries).
 
-1. In **Section 3**, in Folder, create a new folder, by clicking `New folder`{{copy}} and typing a name for the folder. This folder will contain our alerts. For example: `fundamentals`{{copy}}. Then, click `create`{{copy}}.
+1. In **Section 3**, in Folder, create a new folder, by clicking `New folder`{{copy}} and typing a name for the folder. This folder will contain our alert rules. For example: `fundamentals`{{copy}}. Then, click `create`{{copy}}.
 
 1. In the Evaluation group, repeat the above step to create a new one. We will name it `fundamentals`{{copy}} too.
 
-1. Choose an Evaluation interval (how often the alert will be evaluated). For example, every `10s`{{copy}} (10 seconds).
+1. Choose an Evaluation interval (how often the alert rule will be evaluated). For example, every `10s`{{copy}} (10 seconds).
 
-1. Set the pending period. This is the time that a condition has to be met until the alert enters in Firing state and a notification is sent. Enter `0s`{{copy}}. For the purposes of this tutorial, the evaluation interval is intentionally short. This makes it easier to test. This setting makes Grafana wait until an alert has fired for a given time before Grafana sends the notification.
+1. Set the pending period. This is the time that a condition has to be met until the alert instance enters in Firing state and a notification is sent. Enter `0s`{{copy}}. For the purposes of this tutorial, the evaluation interval is intentionally short. This makes it easier to test. This setting makes Grafana wait until an alert instance has fired for a given time before Grafana sends the notification.
 
 1. In **Section 4**, choose **RequestBin** as the **Contact point**.
 
 1. Click **Save rule and exit** at the top of the page.
 
-# Trigger a Grafana Managed Alert
+# Trigger a Grafana-managed alert rule
 
-We have now configured an alert rule and a contact point. Now let’s see if we can trigger a Grafana Managed Alert by generating some traffic on our sample application.
+We have now configured an alert rule and a contact point. Now let’s see if we can trigger a Grafana-managed alert rule by generating some traffic on our sample application.
 
 1. Browse to [localhost:8081]({{TRAFFIC_HOST1_8081}}).
 
 1. Add a new title and URL, repeatedly click the vote button, or refresh the page to generate a traffic spike.
 
-Once the query `sum(rate(tns_request_duration_seconds_count[5m])) by(route)`{{copy}} returns a value greater than `0.2`{{copy}} Grafana will trigger our alert. Browse to the Request Bin we created earlier and find the sent Grafana alert notification with details and metadata.
+Once the query `sum(rate(tns_request_duration_seconds_count[5m])) by(route)`{{copy}} returns a value greater than `0.2`{{copy}} Grafana will trigger our alert rule. Browse to the Request Bin we created earlier and find the sent Grafana alert notification with details and metadata.
 
 Let’s see how we can configure this.
 
@@ -52,15 +52,15 @@ Let’s see how we can configure this.
 
 1. Click the **Edit** icon and scroll down to **Section 5**.
 
-1. Click the **Link dashboard and panel** button and select the dashboard and panel to which you want the alert to be added as an annotation.
+1. Click the **Link dashboard and panel** button and select the dashboard and panel to which you want the alert instance to be added as an annotation.
 
 1. Click **Confirm** and **Save rule and exit** to save all the changes.
 
 1. In Grafana’s sidebar, navigate to the dashboard by clicking **Dashboards** and selecting the dashboard you created.
 
-1. To test the changes, follow the steps listed to [trigger a Grafana Managed Alert](https://grafana.com#trigger-a-grafana-managed-alert).
+1. To test the changes, follow the steps listed to [trigger a Grafana-managed alert rule](https://grafana.com#trigger-a-grafana-managed-alert).
 
-   You should now see a red, broken heart icon beside the panel name, signifying that the alert has been triggered. An annotation for the alert, represented as a vertical red line, is also displayed.
+   You should now see a red, broken heart icon beside the panel name, signifying that the alert rule has been triggered. An annotation for the alert instance, represented as a vertical red line, is also displayed.
 
    ![A panel in a Grafana dashboard with alerting and annotations configured](https://grafana.com/media/tutorials/grafana-alert-on-dashboard.png)
 

--- a/grafana/grafana-fundamentals/step10.md
+++ b/grafana/grafana-fundamentals/step10.md
@@ -18,7 +18,7 @@ Now that Grafana knows how to notify us, it’s time to set up an alert rule:
    sum(rate(tns_request_duration_seconds_count[5m])) by(route)
    ```{{copy}}
 
-1. Press **Preview**. You should see some data returned.
+1. Scroll down to bottom of section #2 and click on the **Preview** button. You should see some data returned.
 
 1. Keep expressions “B” and “C” as they are. These expressions (Reduce and Threshold, respectively) come by default when creating a new rule. Expression “B”, selects the last value of our query “A”, while the Threshold expression “C” will check if the last value from expression “B” is above a specific value. In addition, the Threshold expression is the alert rule condition by default. Enter `0.2`{{copy}} as threshold value. [You can read more about queries and conditions here](https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/queries-conditions/#expression-queries).
 

--- a/grafana/grafana-fundamentals/step2.md
+++ b/grafana/grafana-fundamentals/step2.md
@@ -2,6 +2,4 @@
 
 Grafana is an open-source platform for monitoring and observability that lets you visualize and explore the state of your systems.
 
-1. Open a new tab.
-
 1. Browse to [http://localhost:3000]({{TRAFFIC_HOST1_3000}}).

--- a/grafana/grafana-fundamentals/step3.md
+++ b/grafana/grafana-fundamentals/step3.md
@@ -1,6 +1,6 @@
 # Explore your metrics
 
-Grafana Explore is a workflow for troubleshooting and data exploration. In this step, you’ll be using Explore to create ad-hoc queries to understand the metrics exposed by the sample application.
+Grafana Explore is a workflow for troubleshooting and data exploration. In this step, you’ll be using Explore to create ad-hoc queries to understand the metrics exposed by the sample application. Specifically, you’ll explore requests received by the sample application.
 
 > Ad-hoc queries are queries that are made interactively, with the purpose of exploring data. An ad-hoc query is commonly followed by another, more specific query.
 1. Click the menu icon and, in the sidebar, click **Explore**. A dropdown menu for the list of available data sources is on the upper-left side. The Prometheus data source will already be selected. If not, choose Prometheus.

--- a/grafana/grafana-fundamentals/step7.md
+++ b/grafana/grafana-fundamentals/step7.md
@@ -49,7 +49,7 @@ Manually annotating your dashboard is fine for those single events. For regularl
 
 1. At the top of your dashboard, there is now a toggle to display the results of the newly created annotation query. Press it if it’s not already enabled.
 
-1. Click the **Save dashboard** icon to save the changes.
+1. Click the **Save dashboard** (disk) icon to save the changes.
 
 1. To test the changes, go back to the [sample application]({{TRAFFIC_HOST1_8081}}), post a new link without a URL to generate an error in your browser that says `empty url`{{copy}}.
 

--- a/grafana/grafana-fundamentals/step7.md
+++ b/grafana/grafana-fundamentals/step7.md
@@ -59,4 +59,4 @@ The log lines returned by your query are now displayed as annotations in the gra
 
 Being able to combine data from multiple data sources in one graph allows you to correlate information from both Prometheus and Loki.
 
-Annotations also work very well alongside alerts. In the next and final section, we will set up an alert for our app `grafana.news`{{copy}} and then we will trigger it. This will provide a quick intro to our new Alerting platform.
+Annotations also work very well alongside alert rules. In the next and final section, we will set up an alert rules for our app `grafana.news`{{copy}} and then we will trigger it. This will provide a quick intro to our new Alerting platform.

--- a/grafana/grafana-fundamentals/step8.md
+++ b/grafana/grafana-fundamentals/step8.md
@@ -8,6 +8,19 @@ The most basic alert rule consists of two parts:
 
 1. A _Contact point_ - A Contact point defines how Grafana delivers an alert instance. When the conditions of an _alert rule_ are met, Grafana notifies the contact points, or channels, configured for that alert rule.
 
+   > An [alert instance](https://grafana.com/docs/grafana/latest/alerting/fundamentals/#alert-instances) is a specific occurrence that matches a condition defined by an alert rule, such as when the rate of requests for a specific route suddenly increases.
+   Some popular channels include:
+
+   - [Email](https://grafana.com/docs/grafana/latest/alerting/configure-notifications/manage-contact-points/integrations/configure-email/)
+
+   - [Webhooks](https://grafana.com/docs/grafana/latest/alerting/configure-notifications/manage-contact-points/integrations/webhook-notifier/)
+
+   - [Telegram](https://grafana.com/docs/grafana/latest/alerting/configure-notifications/manage-contact-points/integrations/configure-telegram/)
+
+   - [Slack](https://grafana.com/docs/grafana/latest/alerting/configure-notifications/manage-contact-points/integrations/configure-slack/)
+
+   - [PagerDuty](https://grafana.com/docs/grafana/latest/alerting/configure-notifications/manage-contact-points/integrations/pager-duty/)
+
 1. An _Alert rule_ - An Alert rule defines one or more _conditions_ that Grafana regularly evaluates. When these evaluations meet the rule’s criteria, the alert rule is triggered.
 
 To begin, let’s set up a webhook contact point. Once we have a usable endpoint, we’ll write an alert rule and trigger a notification.

--- a/grafana/grafana-fundamentals/step8.md
+++ b/grafana/grafana-fundamentals/step8.md
@@ -1,25 +1,13 @@
-# Create a Grafana Managed Alert
+# Create a Grafana-managed alert rule
 
-Alerts allow you to identify problems in your system moments after they occur. By quickly identifying unintended changes in your system, you can minimize disruptions to your services.
+Alert rules allow you to identify problems in your system moments after they occur. By quickly identifying unintended changes in your system, you can minimize disruptions to your services.
 
-Grafana’s new alerting platform debuted with Grafana 8. A year later, with Grafana 9, it became the default alerting method. In this step we will create a Grafana Managed Alert. Then we will trigger our new alert and send a test message to a dummy endpoint.
+Grafana’s new alerting platform debuted with Grafana 8. A year later, with Grafana 9, it became the default alerting method. In this step we will create a Grafana-managed alert rule. Then we will trigger our new alert rule and send a test message to a dummy endpoint.
 
-The most basic alert consists of two parts:
+The most basic alert rule consists of two parts:
 
-1. A _Contact point_ - A Contact point defines how Grafana delivers an alert. When the conditions of an _alert rule_ are met, Grafana notifies the contact points, or channels, configured for that alert.
+1. A _Contact point_ - A Contact point defines how Grafana delivers an alert instance. When the conditions of an _alert rule_ are met, Grafana notifies the contact points, or channels, configured for that alert rule.
 
-   Some popular channels include:
-
-   - [Email](https://grafana.com/docs/grafana/latest/alerting/configure-notifications/manage-contact-points/integrations/configure-email/)
-
-   - [Webhooks](https://grafana.com/docs/grafana/latest/alerting/configure-notifications/manage-contact-points/integrations/webhook-notifier/)
-
-   - [Telegram](https://grafana.com/docs/grafana/latest/alerting/configure-notifications/manage-contact-points/integrations/configure-telegram/)
-
-   - [Slack](https://grafana.com/docs/grafana/latest/alerting/configure-notifications/manage-contact-points/integrations/configure-slack/)
-
-   - [PagerDuty](https://grafana.com/docs/grafana/latest/alerting/configure-notifications/manage-contact-points/integrations/pager-duty/)
-
-1. An _Alert rule_ - An Alert rule defines one or more _conditions_ that Grafana regularly evaluates. When these evaluations meet the rule’s criteria, the alert is triggered.
+1. An _Alert rule_ - An Alert rule defines one or more _conditions_ that Grafana regularly evaluates. When these evaluations meet the rule’s criteria, the alert rule is triggered.
 
 To begin, let’s set up a webhook contact point. Once we have a usable endpoint, we’ll write an alert rule and trigger a notification.

--- a/grafana/grafana-fundamentals/step9.md
+++ b/grafana/grafana-fundamentals/step9.md
@@ -12,7 +12,7 @@ Your Request Bin is now waiting for the first request.
 
 Next, let’s configure a Contact Point in Grafana’s Alerting UI to send notifications to our Request Bin.
 
-1. Return to Grafana. In Grafana’s sidebar, hover over the **Alerting** (bell) icon and then click **Contact points**.
+1. Return to Grafana. In Grafana’s sidebar, hover over the **Alerting** (bell) icon and then click **Manage Contact points**.
 
 1. Click **+ Add contact point**.
 

--- a/grafana/grafana-fundamentals/step9.md
+++ b/grafana/grafana-fundamentals/step9.md
@@ -1,6 +1,6 @@
-# Create a contact point for Grafana Managed Alerts
+# Create a contact point for Grafana-managed alert rules
 
-In this step, we’ll set up a new contact point. This contact point will use the _webhooks_ channel. In order to make this work, we also need an endpoint for our webhook channel to receive the alert. We will use [requestbin.com](https://requestbin.com) to quickly set up that test endpoint. This way we can make sure that our alert is actually sending a notification somewhere.
+In this step, we’ll set up a new contact point. This contact point will use the _webhooks_ channel. In order to make this work, we also need an endpoint for our webhook channel to receive the alert notification. We will use [requestbin.com](https://requestbin.com) to quickly set up that test endpoint. This way we can make sure that our alert manager is actually sending a notification somewhere.
 
 1. Browse to [requestbin.com](https://requestbin.com).
 
@@ -22,7 +22,7 @@ Next, let’s configure a Contact Point in Grafana’s Alerting UI to send notif
 
 1. In **URL**, paste the endpoint to your request bin.
 
-1. Click **Test**, and then click **Send test notification** to send a test alert to your request bin.
+1. Click **Test**, and then click **Send test notification** to send a test alert notification to your request bin.
 
 1. Navigate back to the Request Bin you created earlier. On the left side, there’s now a `POST /`{{copy}} entry. Click it to see what information Grafana sent.
 

--- a/grafana/structure.json
+++ b/grafana/structure.json
@@ -2,7 +2,7 @@
     "items": [
         { "path": "grafana-basics", "title": "Grafana Basics"},
         { "path": "alerting-get-started", "title": "Get started with Grafana Alerting"},
-        { "path": "grafana-fundamentals", "title": "Get familiar with Grafana"},
+        { "path": "grafana-fundamentals", "title": "Grafana Fundamentals"},
         { "path": "fo11y", "title": "Frontend Observability"}
     ]
 }


### PR DESCRIPTION
- changes wording so killercoda users aren't asked to "open a new tab" to log in Grafana
- updated all the "alert" occurrences  to either "alert rule" "alert instance", "alert notification", "Grafana-managed alert" rule