### PR TITLE
 Fix admonition preprocessing indentation

### DIFF
--- a/tools/transformer/preprocess.go
+++ b/tools/transformer/preprocess.go
@@ -161,6 +161,10 @@ func (ap *AdmonitionPreprocessor) Process(src []byte) ([]byte, error) {
 
 		for i, definition := range referenceLinkDefinitions {
 			replacement.Write([]byte("\n"))
+
+			for i := 0; i < observedIndentation; i++ {
+				replacement.Write([]byte(" "))
+			}
 			replacement.Write([]byte(definition))
 
 			if i == len(referenceLinkDefinitions)-1 {

--- a/tools/transformer/preprocess_test.go
+++ b/tools/transformer/preprocess_test.go
@@ -110,7 +110,7 @@ Second paragraph.
 		assert.Equal(t, string(want), string(got))
 	})
 
-	t.Run("Note extra empty lines", func(t *testing.T) {
+	t.Run("Note with extra empty lines", func(t *testing.T) {
 		t.Parallel()
 
 		pp := NewAdmonitionPreprocessor()
@@ -129,6 +129,43 @@ Second paragraph.
 > This is a note.
 >
 > Second paragraph.
+`
+
+		got, err := pp.Process(src)
+		require.NoError(t, err)
+		assert.Equal(t, string(want), string(got))
+	})
+
+	t.Run("Indented note", func(t *testing.T) {
+		t.Parallel()
+
+		pp := NewAdmonitionPreprocessor()
+		src := []byte(`1. First step
+
+   {{< admonition type="note" >}}
+
+   This is a note.
+
+   Second paragraph.
+
+   {{< /admonition >}}
+
+2. Second step
+`)
+		want := `1. First step
+
+   > **Note:**
+   > This is a note.
+   >
+   > Second paragraph.
+
+2. Second step
+`
+
+		got, err := pp.Process(src)
+		require.NoError(t, err)
+		assert.Equal(t, string(want), string(got))
+	})
 `
 
 		got, err := pp.Process(src)

--- a/tools/transformer/preprocess_test.go
+++ b/tools/transformer/preprocess_test.go
@@ -166,6 +166,25 @@ Second paragraph.
 		require.NoError(t, err)
 		assert.Equal(t, string(want), string(got))
 	})
+
+	t.Run("Note with reference style link", func(t *testing.T) {
+		t.Parallel()
+
+		pp := NewAdmonitionPreprocessor()
+		src := []byte(`{{< admonition type="tip" >}}
+The basic_auth block is commented out because the local docker compose stack doesn't require it.
+It's included in this example to show how you can configure authorization for other environments.
+For further authorization options, refer to the [loki.write][loki.write] component reference.
+
+[loki.write]: ../../reference/components/loki/loki.write/
+{{< /admonition >}}
+`)
+		want := `> **Tip:**
+> The basic_auth block is commented out because the local docker compose stack doesn't require it.
+> It's included in this example to show how you can configure authorization for other environments.
+> For further authorization options, refer to the [loki.write][loki.write] component reference.
+
+[loki.write]: ../../reference/components/loki/loki.write/
 `
 
 		got, err := pp.Process(src)


### PR DESCRIPTION
Previously the tool wasn't keeping indentation which was causing ambiguous output for notes inside lists.

Additionally, move reference link definitions outside of the blockquote for a cleaner Markdown output.
