### PR TITLE
Harden workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,11 @@ jobs:
     if: github.repository == 'grafana/killercoda'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: killercoda
-      - uses: actions/setup-go@v5
+          persist-credentials: false
+      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
           go-version-file: killercoda/tools/transformer/go.mod
       - run: go test ./...

--- a/.github/workflows/regenerate-tutorials.yml
+++ b/.github/workflows/regenerate-tutorials.yml
@@ -9,34 +9,41 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Check out all the repositories that contain documentation sources from which we generate tutorials.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          repository: grafana/loki
           path: loki
-      - uses: actions/checkout@v4
+          persist-credentials: false
+          repository: grafana/loki
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          repository: grafana/grafana
           path: grafana
-      - uses: actions/checkout@v4
+          persist-credentials: false
+          repository: grafana/grafana
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-            repository: grafana/alloy
-            path: alloy
-      - uses: actions/checkout@v4
+          path: alloy
+          persist-credentials: false
+          repository: grafana/alloy
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-            repository: grafana/tempo
-            path: tempo
-      - uses: actions/checkout@v4
+          path: tempo
+          persist-credentials: false
+          repository: grafana/tempo
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-            repository: grafana/mimir
-            path: mimir
-      - uses: actions/checkout@v4
+          path: mimir
+          persist-credentials: false
+          repository: grafana/mimir
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-            repository: grafana/pyroscope
-            path: pyroscope
-      - uses: actions/checkout@v4
+          path: pyroscope
+          persist-credentials: false
+          repository: grafana/pyroscope
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: killercoda
-      - uses: actions/setup-go@v5
+          persist-credentials: false
+      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
           go-version-file: killercoda/tools/transformer/go.mod
       - run: go build ./

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,22 +14,23 @@ jobs:
         os: [linux, darwin, windows] # Target operating systems
         arch: [amd64, arm64] # Target architectures
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          go-version: '1.23' # Adjust this based on the version you need
+          persist-credentials: false
+
+      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        with:
+          cache: false
+          go-version-file: killercoda/tools/transformer/go.mod
 
       - name: Build transformer
         working-directory: ./tools/transformer
         run: |
           mkdir -p ../../release
           GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o ../../release/transformer-${{ matrix.os }}-${{ matrix.arch }}
-        
+
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: transformer-${{ matrix.os }}-${{ matrix.arch }}
           path: release/transformer-${{ matrix.os }}-${{ matrix.arch }}
@@ -39,12 +40,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           path: release
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
         with:
           files: release/**
         env:


### PR DESCRIPTION
- Pin actions to immutable references
- Don't persist Git credentials so they can't be used in later steps
- Don't use a cache during release workflows to avoid cache poisoning

Found using [`zizmor`](https://woodruffw.github.io/zizmor/):

```console
zizmor --persona auditor --quiet "--gh-token=${GITHUB_TOKEN}" *.yml
```