### PR TITLE
Ensure script has access to workflow token

### DIFF
--- a/.github/workflows/regenerate-tutorials.yml
+++ b/.github/workflows/regenerate-tutorials.yml
@@ -49,6 +49,8 @@ jobs:
       - run: go build ./
         working-directory: killercoda/tools/transformer
       - run: ./scripts/check-out-branch.bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         working-directory: killercoda
       # Run the transformer on all documentation sources.

--- a/scripts/manage-pr.bash
+++ b/scripts/manage-pr.bash
@@ -27,6 +27,7 @@ function commit {
   git add .
   git config --local user.email bot@grafana.com
   git config --local user.name grafanabot
+  git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/grafana/killercoda"
   git commit --message "${SUBJECT}"
 }
 


### PR DESCRIPTION
Before, this was working because the `actions/checkout` action was leaking credentials out to the script.

It broke, rightfully, after #200 