### PR TITLE
Add support for unsafe HTML rendering

### DIFF
--- a/tools/transformer/goldmark/goldmark.go
+++ b/tools/transformer/goldmark/goldmark.go
@@ -35,7 +35,8 @@ func NewWebsite() *Extension {
 			extension.Strikethrough,
 			extension.Table,
 			extension.TaskList,
-			extension.Typographer,
+			// Disable typographer because we want to keep the Markdown source as close to the rendered output as possible.
+			// extension.Typographer,
 			meta.New(meta.WithStoresInDocument()),
 		},
 		ParserOptions: []parser.Option{

--- a/tools/transformer/goldmark/renderer/markdown/block.go
+++ b/tools/transformer/goldmark/renderer/markdown/block.go
@@ -155,10 +155,6 @@ func (r *Renderer) renderListItem(w util.BufWriter, _ []byte, node ast.Node, ent
 		r.pushPrefix(indent)
 	} else {
 		r.popPrefix(indent)
-
-		if node.NextSibling() != nil {
-			r.write(w, '\n')
-		}
 	}
 
 	return ast.WalkContinue, nil

--- a/tools/transformer/goldmark/renderer/markdown/block.go
+++ b/tools/transformer/goldmark/renderer/markdown/block.go
@@ -105,10 +105,25 @@ func (r *Renderer) renderHTMLBlock(w util.BufWriter, source []byte, node ast.Nod
 	n := node.(*ast.HTMLBlock)
 
 	if entering {
-		r.write(w, "<!-- raw HTML omitted -->\n")
+		if r.Unsafe {
+			l := n.Lines().Len()
+
+			for i := 0; i < l; i++ {
+				line := n.Lines().At(i)
+				r.secureWrite(w, line.Value(source))
+			}
+		} else {
+			r.write(w, "<!-- raw HTML omitted -->\n")
+		}
 	} else {
 		if n.HasClosure() {
-			r.write(w, "<!-- raw HTML omitted -->\n")
+			if r.Unsafe {
+				closure := n.ClosureLine
+
+				r.secureWrite(w, closure.Value(source))
+			} else {
+				r.write(w, "<!-- raw HTML omitted -->\n")
+			}
 		}
 
 		if n.NextSibling() != nil {

--- a/tools/transformer/goldmark/renderer/markdown/block_test.go
+++ b/tools/transformer/goldmark/renderer/markdown/block_test.go
@@ -68,7 +68,6 @@ func TestRenderDocument(t *testing.T) {
 		"   ```bash\n" +
 		"   echo 'Hello, world!'\n" +
 		"   ```\n" +
-		"\n" +
 		"1. of two items\n")
 	root := md.Parser().Parse(text.NewReader(src))
 
@@ -121,15 +120,10 @@ func TestRenderList(t *testing.T) {
 	md := goldmark.New(goldmark.WithExtensions(NewRenderer()))
 
 	src := []byte(`- One
-
   - A
-
 - Two
-
   - B
-
 - Three
-
   - C
 `)
 	root := md.Parser().Parse(text.NewReader(src))

--- a/tools/transformer/goldmark/renderer/markdown/inline.go
+++ b/tools/transformer/goldmark/renderer/markdown/inline.go
@@ -116,7 +116,17 @@ func (r *Renderer) renderRawHTML(w util.BufWriter, source []byte, node ast.Node,
 		return ast.WalkSkipChildren, nil
 	}
 
-	r.write(w, "<!-- raw HTML omitted -->")
+	if r.Unsafe {
+		n := node.(*ast.RawHTML)
+		l := n.Segments.Len()
+
+		for i := 0; i < l; i++ {
+			segment := n.Segments.At(i)
+			r.secureWrite(w, segment.Value(source))
+		}
+	} else {
+		r.write(w, "<!-- raw HTML omitted -->")
+	}
 
 	return ast.WalkSkipChildren, nil
 }
@@ -144,6 +154,7 @@ func (r *Renderer) renderText(w util.BufWriter, source []byte, node ast.Node, en
 	value := segment.Value(source)
 
 	r.write(w, value)
+
 	if n.HardLineBreak() {
 		r.write(w, "\n\n")
 	} else if n.SoftLineBreak() {

--- a/tools/transformer/goldmark/renderer/markdown/inline.go
+++ b/tools/transformer/goldmark/renderer/markdown/inline.go
@@ -45,6 +45,7 @@ func (r *Renderer) renderCodeSpan(w util.BufWriter, source []byte, node ast.Node
 	}
 
 	r.write(w, '`')
+
 	if r.Config.KillercodaActions {
 		if _, ok := node.AttributeString("data-killercoda-copy"); ok {
 			r.write(w, "{{copy}}")
@@ -54,19 +55,18 @@ func (r *Renderer) renderCodeSpan(w util.BufWriter, source []byte, node ast.Node
 	return ast.WalkContinue, nil
 }
 
+// renderEmphasis renders emphasis.
+// Correctly rendering emphasis is a lot more complicated that this function.
+// https://spec.commonmark.org/0.31.2/#emphasis-and-strong-emphasis
 func (r *Renderer) renderEmphasis(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	n := node.(*ast.Emphasis)
-
 	delim := "_"
+
 	if n.Level == 2 {
 		delim = "**"
 	}
 
-	if entering {
-		r.write(w, delim)
-	} else {
-		r.write(w, delim)
-	}
+	r.write(w, delim)
 
 	return ast.WalkContinue, nil
 }
@@ -85,6 +85,7 @@ func (r *Renderer) renderImage(w util.BufWriter, source []byte, node ast.Node, e
 			r.write(w, n.Title)
 			r.write(w, "\"")
 		}
+
 		r.write(w, ')')
 	}
 
@@ -105,6 +106,7 @@ func (r *Renderer) renderLink(w util.BufWriter, _ []byte, node ast.Node, enterin
 			r.write(w, n.Title)
 			r.write(w, "\"")
 		}
+
 		r.write(w, ')')
 	}
 

--- a/tools/transformer/goldmark/renderer/markdown/markdown.go
+++ b/tools/transformer/goldmark/renderer/markdown/markdown.go
@@ -90,6 +90,31 @@ func (r *Renderer) write(w util.BufWriter, writee any) {
 	}
 }
 
+// secureWrite writes the source to the buf writer, replacing any null characters with the replacement character.
+// https://github.com/yuin/goldmark/blob/04410ff159c9f5fd61c2988402355e44ec9197f5/renderer/html/html.go#L869-L884
+func (r *Renderer) secureWrite(w util.BufWriter, source []byte) {
+	var (
+		n int
+		l = len(source)
+	)
+
+	for i := 0; i < l; i++ {
+		if source[i] == '\u0000' {
+			r.write(w, source[i-n:i])
+			n = 0
+			r.write(w, []byte("\ufffd"))
+
+			continue
+		}
+
+		n++
+	}
+
+	if n != 0 {
+		r.write(w, source[l-n:])
+	}
+}
+
 func (r *Renderer) writeLines(w util.BufWriter, source []byte, n ast.Node) {
 	for i := 0; i < n.Lines().Len(); i++ {
 		line := n.Lines().At(i)
@@ -99,12 +124,14 @@ func (r *Renderer) writeLines(w util.BufWriter, source []byte, n ast.Node) {
 
 type Config struct {
 	KillercodaActions bool
+	Unsafe            bool
 }
 
 // NewConfig returns a new Config with defaults.
 func NewConfig() Config {
 	return Config{
 		KillercodaActions: false,
+		Unsafe:            false,
 	}
 }
 
@@ -113,6 +140,8 @@ func (c *Config) SetOption(name renderer.OptionName, value interface{}) {
 	switch name {
 	case optKillercodaActions:
 		c.KillercodaActions = value.(bool)
+	case optUnsafe:
+		c.Unsafe = value.(bool)
 	}
 }
 
@@ -123,8 +152,7 @@ type Option interface {
 
 const optKillercodaActions renderer.OptionName = "KillercodaActions"
 
-type withKillercodaActions struct {
-}
+type withKillercodaActions struct{}
 
 func (o *withKillercodaActions) SetConfig(c *renderer.Config) {
 	c.Options[optKillercodaActions] = true
@@ -141,6 +169,26 @@ func WithKillercodaActions() interface {
 	Option
 } {
 	return &withKillercodaActions{}
+}
+
+const optUnsafe renderer.OptionName = "Unsafe"
+
+type withUnsafe struct{}
+
+func (o *withUnsafe) SetConfig(c *renderer.Config) {
+	c.Options[optUnsafe] = true
+}
+
+func (o *withUnsafe) SetMarkdownOption(c *Config) {
+	c.Unsafe = true
+}
+
+// WithUnsafe decides whether to render unsafe HTML.
+func WithUnsafe() interface {
+	renderer.Option
+	Option
+} {
+	return &withUnsafe{}
 }
 
 type Renderer struct {

--- a/tools/transformer/transform_test.go
+++ b/tools/transformer/transform_test.go
@@ -396,9 +396,7 @@ The Docker Compose configuration instantiates the following components, each in 
 
 - **flog** a sample application which generates log lines.
   [flog](https://github.com/mingrammer/flog) is a log generator for common log formats.
-
 - **Grafana Alloy** which scrapes the log lines from flog, and pushes them to Loki through the gateway.
-
 - **Grafana** which provides visualization of the log lines captured within Loki.
 `
 


### PR DESCRIPTION
Let's me roundtrip Markdown sources with HTML in them.

Also:
- [Disable Typographer extension to avoid smartquotes being added to roundtrip source](https://github.com/grafana/killercoda/commit/e08b63638a814673221113e3e1de5ca1e0fd3a11) 
- [Make lists cosy](https://github.com/grafana/killercoda/commit/c6a68ba1d2fe18604c37c14715241604a71df0c2)

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>