### PR TITLE
Fix permissions to allow regeneration to pull and commit and release to pull

### DIFF
--- a/.github/workflows/regenerate-tutorials.yml
+++ b/.github/workflows/regenerate-tutorials.yml
@@ -11,6 +11,7 @@ jobs:
   main:
     permissions:
       contents: write
+      pull-requests: write
     if: github.repository == 'grafana/killercoda'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/regenerate-tutorials.yml
+++ b/.github/workflows/regenerate-tutorials.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   main:
+    permissions:
+      contents: write
     if: github.repository == 'grafana/killercoda'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   build-and-release:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/scripts/check-out-branch.bash
+++ b/scripts/check-out-branch.bash
@@ -19,6 +19,10 @@ if [[ $# -ne 0 ]]; then
   exit 1
 fi
 
+if [ -n "${RUNNER_DEBUG+x}" ]; then
+  set -x
+fi
+
 readonly BRANCH="${BRANCH:-update-generated-tutorials}"
 
 PR_STATUS=$(gh pr view "${BRANCH}" --json state --jq .state || true)

--- a/scripts/check-out-branch.bash
+++ b/scripts/check-out-branch.bash
@@ -41,6 +41,10 @@ fi
 
 # Remove the remote branch if it exists because there is no PR associated with it.
 if git fetch origin "${BRANCH}"; then
+  git config --local user.email bot@grafana.com
+  git config --local user.name grafanabot
+  git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/grafana/killercoda"
+
   git push origin --delete "${BRANCH}"
 fi
 

--- a/scripts/manage-pr.bash
+++ b/scripts/manage-pr.bash
@@ -19,6 +19,10 @@ if [[ $# -ne 0 ]]; then
   exit 1
 fi
 
+if [ -n "${RUNNER_DEBUG+x}" ]; then
+  set -x
+fi
+
 readonly BRANCH="${BRANCH:-update-generated-tutorials}"
 readonly SUBJECT="${SUBJECT:-Update generated tutorials}"
 


### PR DESCRIPTION
Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

Tutorial regeneration worked in https://github.com/grafana/killercoda/actions/runs/15297760246 and opened https://github.com/grafana/killercoda/pull/239